### PR TITLE
refactor some duplications

### DIFF
--- a/lib/crest.rb
+++ b/lib/crest.rb
@@ -2,101 +2,100 @@ require 'inflecto'
 
 module Crest
   def rest(klass, options = {}, &block)
-    self.class.send :define_method, :"find_#{object_name klass}" do |id|
+    collection_name = Inflecto.underscore Inflecto.pluralize(klass)
+    object_name = Inflecto.underscore klass
+
+    define_handler "find_#{object_name}" do |id|
       klass[id]
-    end unless respond_to? :"find_#{object_name klass}"
+    end
 
-    self.class.send :define_method, :"find_#{collection_name klass}" do
+    define_handler "find_#{collection_name}" do
       klass.all
-    end unless respond_to? :"find_#{collection_name klass}"
+    end
 
-    self.class.send :define_method, :"list_#{collection_name klass}" do
-      render "#{collection_name klass}/list", :"#{collection_name klass}" => send(:"find_#{collection_name klass}")
-    end unless respond_to? :"list_#{collection_name klass}"
+    define_handler "list_#{collection_name}" do
+      render "#{collection_name}/list", :"#{collection_name}" => send(:"find_#{collection_name}")
+    end
 
-    self.class.send :define_method, :"create_#{object_name klass}" do |object_params|
+    define_handler "create_#{object_name}" do |object_params|
       object = klass.new object_params
       if object.valid?
         object.save
-        res.redirect "#{options[:base_uri]}/#{collection_name klass}/#{object.id}"
+        res.redirect "#{options[:base_uri]}/#{collection_name}/#{object.id}"
       else
-        render "#{collection_name klass}/new", :"#{object_name klass}" => object
+        render "#{collection_name}/new", :"#{object_name}" => object
       end
-    end unless respond_to? :"create_#{object_name klass}"
+    end
 
-    self.class.send :define_method, :"new_#{object_name klass}" do
-      render "#{collection_name klass}/new", :"#{object_name klass}" => klass.new
-    end unless respond_to? :"new_#{object_name klass}"
+    define_handler "new_#{object_name}" do
+      render "#{collection_name}/new", :"#{object_name}" => klass.new
+    end
 
-    self.class.send :define_method, :"show_#{object_name klass}" do |object|
-      render "#{collection_name klass}/show", :"#{object_name klass}" => object
-    end unless respond_to? :"show_#{object_name klass}"
+    define_handler "show_#{object_name}" do |object|
+      render "#{collection_name}/show", :"#{object_name}" => object
+    end
 
-    self.class.send :define_method, :"update_#{object_name klass}" do |object, object_params|
+    define_handler "update_#{object_name}" do |object, object_params|
       object.set_all object_params
       if object.valid?
         object.save
-        res.redirect "#{options[:base_uri]}/#{collection_name klass}/#{object.id}"
+        res.redirect "#{options[:base_uri]}/#{collection_name}/#{object.id}"
       else
-        render "#{collection_name klass}/edit", :"#{object_name klass}" => object
+        render "#{collection_name}/edit", :"#{object_name}" => object
       end
-    end unless respond_to? :"update_#{object_name klass}"
+    end
 
-    self.class.send :define_method, :"delete_#{object_name klass}" do |object|
+    define_handler "delete_#{object_name}" do |object|
       object.delete
-      res.redirect "#{options[:base_uri]}/#{collection_name klass}"
-    end unless respond_to? :"delete_#{object_name klass}"
+      res.redirect "#{options[:base_uri]}/#{collection_name}"
+    end
 
-    self.class.send :define_method, :"edit_#{object_name klass}" do |object|
-      render "#{collection_name klass}/edit", :"#{object_name klass}" => object
-    end unless respond_to? :"edit_#{object_name klass}"
+    define_handler "edit_#{object_name}" do |object|
+      render "#{collection_name}/edit", :"#{object_name}" => object
+    end
 
     block.call unless block.nil?
 
     on root do
       on get do
-        send :"list_#{collection_name klass}"
+        send :"list_#{collection_name}"
       end
 
-      on post, param(:"#{object_name klass}") do |object_params|
-        send :"create_#{object_name klass}", object_params
+      on post, param(:"#{object_name}") do |object_params|
+        send :"create_#{object_name}", object_params
       end
     end
 
     on get, 'new' do
-      send :"new_#{object_name klass}"
+      send :"new_#{object_name}"
     end
 
     on :id do |id|
-      object = send :"find_#{object_name klass}", id
+      object = send :"find_#{object_name}", id
 
       on root do
         on get do
-          send :"show_#{object_name klass}", object
+          send :"show_#{object_name}", object
         end
 
-        on put, param(:"#{object_name klass}") do |object_params|
-          send :"update_#{object_name klass}", object, object_params
+        on put, param(:"#{object_name}") do |object_params|
+          send :"update_#{object_name}", object, object_params
         end
 
         on delete do
-          send :"delete_#{object_name klass}", object
+          send :"delete_#{object_name}", object
         end
       end
 
       on 'edit' do
-        send :"edit_#{object_name klass}", object
+        send :"edit_#{object_name}", object
       end
     end
   end
 
   private
 
-  def collection_name(klass)
-    Inflecto.underscore Inflecto.pluralize(klass)
-  end
-
-  def object_name(klass)
-    Inflecto.underscore klass
+  def define_handler(name, &body)
+    self.class.send(:define_method, name, &body)  unless respond_to? name
   end
 end


### PR DESCRIPTION
- Added a #define_handler to define instance methods on the app class if they are not defined. 
- Also, removed  the `#collection_name` & `#object_name methods`, as they only have sense when defining the handlers and routes on the app. Based on this argument, the first method should not be an instance method either, but reads better than having an inner lambda to do the same stuff. This also suggests that perhaps there is another object trying to emerge out from this, but... 
  Thoughts?
